### PR TITLE
Added ability to ignore "on the page" css

### DIFF
--- a/miner.js
+++ b/miner.js
@@ -39,6 +39,7 @@
     options.limit = options.limit || 0;
     options.element = options.element || 'body';
     options.exclude = options.exclude || [];
+    options.ignoreInlineCSS = options.ignoreInlineCSS || true;
 
     var protocol =
       options.site.indexOf('https://') !== -1 ?
@@ -52,11 +53,19 @@
             corpus = new miner.Corpus([]),
             words = [],
             terms,
-            dom;
+            dom,
+            doc;
         response.on('data', function (data) { body += data; });
         response.on('end', function () {
           dom = cheerio.load(body);
-          corpus.addDoc(dom(options.element).text());
+          if (options.ignoreInlineCSS) {
+            doc = dom(options.element).html().replace(/style=(['"])[^\1]*?\1/ig, '').replace(/<style[^<]*?<\/style>/ig, '');
+            doc = dom(doc).text();
+          } else {
+            doc = dom(options.element).text();
+          }
+
+          corpus.addDoc(doc);
           corpus
             .trim()
             .toLower()


### PR DESCRIPTION
While using keyword-miner, I noticed that a few of the sites I was scanning were listing things like "px" and "important" as top keywords.

This pull request adds an extra option that strips out inline styles and style blocks. Might not be the cleanest method but I have tested it against sites that have a lot of css on the page.
